### PR TITLE
minor fix

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -24,7 +24,7 @@ onMounted(() => {
   <lenis id="test" ref="lenisRef" :options="lenisOptions" @scroll="scrollEmitter">
     <div class="glowball "></div>
     <SeoKit />
-    <div class="py-5 bg-black">
+    <div class="pt-5 bg-black">
       <NuxtLayout>
         <NuxtPage />
       </NuxtLayout>

--- a/components/TheChip.vue
+++ b/components/TheChip.vue
@@ -1,6 +1,11 @@
+<script setup lang="ts">
+defineProps({ selected: Boolean })
+</script>
 <template>
     <div>
-        <div class="rounded-full border border-[#999] px-2 py-1.5 text-xs w-fit uppercase mr-2 whitespace-nowrap cursor-pointer hover:bg-[#999] hover:text-white hover:border-[#999] hover:transition duration-200 ease-in-out">
+        <div 
+        :class="[selected ? 'bg-gray-200 text-gray-800' : '']"
+        class="rounded-full border border-[#999] px-2 py-1.5 text-xs w-fit uppercase mr-2 whitespace-nowrap cursor-pointer hover:bg-[#999] hover:text-white hover:border-[#999] hover:transition duration-200 ease-in-out">
             <slot/>
         </div>
     </div>

--- a/components/TheTalksSearch.vue
+++ b/components/TheTalksSearch.vue
@@ -62,7 +62,7 @@ const clearSelectedCategory = () => {
       </div>
       <input
         v-model="localSearchQuery"
-        class="bg-transparent rounded-xl w-full h-[45px] pl-4 py-3 text-[#999] text-2xl font-semibold tracking-[-0.84px] focus:border-none active:border-none focus-visible:border-none focus:outline-none placeholder:text-[#878787]"
+        class="bg-transparent border-none rounded-xl w-full h-[45px] pl-4 py-3 text-[#999] text-2xl font-semibold tracking-[-0.84px] focus:border-none active:border-none focus-visible:border-none focus:outline-none focus:ring-0 placeholder:text-[#878787]"
         placeholder="Search"
         type="text"
         required
@@ -79,6 +79,7 @@ const clearSelectedCategory = () => {
         v-for="talk in talkCategories"
         :key="talk"
         @click="selectedCategory = talk"
+        :selected="selectedCategory === talk"
       >
         {{ talk }}
       </TheChip>

--- a/components/TheVerticalGrid.vue
+++ b/components/TheVerticalGrid.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="w-full h-full -z-1 absolute flex flex-row justify-between left-0 lg:h-full lg:max-w-7xl lg:px-0 mx-auto px-6 right-0"
+    class="w-full max-h-screen h-full -z-1 absolute flex flex-row justify-between left-0 lg:h-full lg:max-w-7xl lg:px-0 mx-auto px-6 right-0"
   >
     <div
       class="w-full h-full border-[#f5f5f510]/5 border-x border-dashed"

--- a/pages/articles.vue
+++ b/pages/articles.vue
@@ -115,7 +115,7 @@ useSeoMeta({
       </TheWrapper>
     </section>
     <section
-      class="z-20 mb-24 sticky top-0 pt-20 md:pt-6 bg-black/80 backdrop-blur-lg"
+      class="z-20 mb-24 sticky top-0 pt-20 md:pt-20 bg-black/80 backdrop-blur-lg"
     >
       <TheWrapper>
         <div>
@@ -167,6 +167,7 @@ useSeoMeta({
               v-for="articleCategory in nuxtContentCategories"
               :key="articleCategory"
               @click="selectedCategory = articleCategory"
+              :selected="selectedCategory === articleCategory"
             >
               {{ articleCategory }}
             </TheChip>


### PR DESCRIPTION
1. app.vue:
•  Minor styling change: Changed py-5 to pt-5 in the background div class, removing bottom padding while keeping top padding

2. components/TheChip.vue:
•  Added TypeScript setup script with a new selected prop
•  Enhanced the component to support a selected state
•  Added conditional styling that applies bg-gray-200 and text-gray-800 classes when the chip is selected

3. components/TheTalksSearch.vue:
•  Enhanced input field styling by adding border-none and focus:ring-0 classes
•  Added the :selected prop to TheChip components to track the selected category
•  Connected the selected state to the selectedCategory value

4. pages/articles.vue:
•  Modified the sticky section's padding on medium screens from md:pt-6 to md:pt-20
•  Added the :selected prop to TheChip components for article categories
•  Connected the selected state to the selectedCategory value